### PR TITLE
refactor: update deprecated task identifiers in examples

### DIFF
--- a/src/main/java/io/kestra/plugin/email/MailReceivedTrigger.java
+++ b/src/main/java/io/kestra/plugin/email/MailReceivedTrigger.java
@@ -43,7 +43,7 @@ import lombok.experimental.SuperBuilder;
 
                 tasks:
                   - id: process_email
-                    type: io.kestra.core.tasks.log.Log
+                    type: io.kestra.plugin.core.log.Log
                     message: |
                       New email received:
                       Subject: {{ trigger.latestEmail.subject }}

--- a/src/main/java/io/kestra/plugin/email/RealTimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/email/RealTimeTrigger.java
@@ -54,7 +54,7 @@ import reactor.core.publisher.FluxSink;
 
                 tasks:
                   - id: process_email
-                    type: io.kestra.core.tasks.log.Log
+                    type: io.kestra.plugin.core.log.Log
                     message: |
                       Real-time email received:
                       Subject: {{ trigger.subject }}

--- a/src/test/resources/flows/common/main-flow-that-fails.yaml
+++ b/src/test/resources/flows/common/main-flow-that-fails.yaml
@@ -2,4 +2,4 @@ id: main-flow-that-fails
 namespace: io.kestra.tests
 tasks:
   - id: failed
-    type: io.kestra.core.tasks.executions.Fail
+    type: io.kestra.plugin.core.execution.Fail


### PR DESCRIPTION
Update the old task names in the examples to the current ones.