### PR TITLE
fix: make the Simple Java Mail 9.1.0 upgrade pass

### DIFF
--- a/src/main/java/io/kestra/plugin/email/MailSend.java
+++ b/src/main/java/io/kestra/plugin/email/MailSend.java
@@ -378,8 +378,10 @@ public class MailSend extends Task implements RunnableTask<VoidOutput> {
             .orElse("Please view this email in a modern email client");
 
         EmailPopulatingBuilder builder = EmailBuilder.startingBlank()
-            .withRecipients(null, false, RecipientType.TO, runContext.render(to).as(String.class).orElseThrow())
-            .from(runContext.render(from).as(String.class).orElseThrow())
+            .withRecipients(null, false, RecipientType.TO, runContext.render(to).as(String.class)
+                .orElseThrow(() -> new IllegalArgumentException("'to' must be set to send an email")))
+            .from(runContext.render(from).as(String.class)
+                .orElseThrow(() -> new IllegalArgumentException("'from' must be set to send an email")))
             .withSubject(runContext.render(subject).as(String.class).orElse(null))
             .withHTMLText(htmlContent)
             .withPlainText(textContent)

--- a/src/main/java/io/kestra/plugin/email/MailSend.java
+++ b/src/main/java/io/kestra/plugin/email/MailSend.java
@@ -27,6 +27,7 @@ import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.JacksonMapper;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.mail.Message.RecipientType;
 import jakarta.mail.util.ByteArrayDataSource;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -377,7 +378,7 @@ public class MailSend extends Task implements RunnableTask<VoidOutput> {
             .orElse("Please view this email in a modern email client");
 
         EmailPopulatingBuilder builder = EmailBuilder.startingBlank()
-            .to(runContext.render(to).as(String.class).orElseThrow())
+            .withRecipients(null, false, RecipientType.TO, runContext.render(to).as(String.class).orElseThrow())
             .from(runContext.render(from).as(String.class).orElseThrow())
             .withSubject(runContext.render(subject).as(String.class).orElse(null))
             .withHTMLText(htmlContent)
@@ -398,8 +399,8 @@ public class MailSend extends Task implements RunnableTask<VoidOutput> {
             builder.withEmbeddedImages(this.attachmentResources(embeddedImagesList, runContext));
         }
 
-        runContext.render(cc).as(String.class).ifPresent(builder::cc);
-        runContext.render(bcc).as(String.class).ifPresent(builder::bcc);
+        runContext.render(cc).as(String.class).ifPresent(address -> builder.withRecipients(null, false, RecipientType.CC, address));
+        runContext.render(bcc).as(String.class).ifPresent(address -> builder.withRecipients(null, false, RecipientType.BCC, address));
 
         return builder.buildEmail();
     }

--- a/src/test/java/io/kestra/plugin/email/MailSendTest.java
+++ b/src/test/java/io/kestra/plugin/email/MailSendTest.java
@@ -199,12 +199,13 @@ public class MailSendTest {
         assertThat(body, containsString("<strong>Status :</strong> SUCCE=\r\nSS"));
         assertThat(body, containsString("<strong>Env :</strong> dev"));
         assertThat(body, containsString("myCustomMessage"));
-        assertThat(body, containsString("Content-Type: image/png; filename=kestra.png; name=kestra.png"));
+        assertThat(body, containsString("Content-Type: image/png; name=kestra.png"));
+        assertThat(body, containsString("Content-Disposition: inline; filename=kestra.png"));
 
         MimeBodyPart filePart = ((MimeBodyPart) content.getBodyPart(1));
         String file = IOUtils.toString(filePart.getInputStream(), StandardCharsets.UTF_8);
 
-        assertThat(filePart.getContentType(), is("text/yaml; filename=" + attachmentFilename + "; name=" + attachmentFilename));
+        assertThat(filePart.getContentType(), is("text/yaml; name=" + attachmentFilename));
         assertThat(filePart.getFileName(), is(attachmentFilename));
         assertThat(file.replace("\r", ""), is(IOUtils.toString(storageInterface.get(MAIN_TENANT, null, putAttachment), StandardCharsets.UTF_8)));
     }


### PR DESCRIPTION
Companion fix for #60. This keeps the dependency update in the existing Dependabot PR and adds only the compatibility changes it needs.

- replace the removed `to`, `cc`, and `bcc` builder shortcuts with the supported `withRecipients` API while preserving recipient types and address parsing
- update MIME assertions for Simple Java Mail 9 removing the non-standard `filename` parameter from `Content-Type`; attachment filenames remain asserted through `Content-Disposition` and `MimeBodyPart#getFileName()`

Verification on JDK 21:

- `./gradlew test --tests io.kestra.plugin.email.MailSendTest --rerun-tasks --no-daemon --max-workers=6`
- `./gradlew clean check --no-daemon --max-workers=6` (25 plugin-doc rules and all 9 tests passed)