### PR TITLE
Migrate recipient construction to Simple Java Mail 9

### DIFF
--- a/src/main/java/io/kestra/plugin/email/MailSend.java
+++ b/src/main/java/io/kestra/plugin/email/MailSend.java
@@ -27,6 +27,7 @@ import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.JacksonMapper;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.mail.Message;
 import jakarta.mail.util.ByteArrayDataSource;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -377,7 +378,12 @@ public class MailSend extends Task implements RunnableTask<VoidOutput> {
             .orElse("Please view this email in a modern email client");
 
         EmailPopulatingBuilder builder = EmailBuilder.startingBlank()
-            .to(runContext.render(to).as(String.class).orElseThrow())
+            .withRecipients(
+                null,
+                false,
+                Message.RecipientType.TO,
+                runContext.render(to).as(String.class).orElseThrow()
+            )
             .from(runContext.render(from).as(String.class).orElseThrow())
             .withSubject(runContext.render(subject).as(String.class).orElse(null))
             .withHTMLText(htmlContent)
@@ -398,8 +404,12 @@ public class MailSend extends Task implements RunnableTask<VoidOutput> {
             builder.withEmbeddedImages(this.attachmentResources(embeddedImagesList, runContext));
         }
 
-        runContext.render(cc).as(String.class).ifPresent(builder::cc);
-        runContext.render(bcc).as(String.class).ifPresent(builder::bcc);
+        runContext.render(cc).as(String.class).ifPresent(
+            value -> builder.withRecipients(null, false, Message.RecipientType.CC, value)
+        );
+        runContext.render(bcc).as(String.class).ifPresent(
+            value -> builder.withRecipients(null, false, Message.RecipientType.BCC, value)
+        );
 
         return builder.buildEmail();
     }

--- a/src/test/java/io/kestra/plugin/email/MailSendTest.java
+++ b/src/test/java/io/kestra/plugin/email/MailSendTest.java
@@ -199,14 +199,19 @@ public class MailSendTest {
         assertThat(body, containsString("<strong>Status :</strong> SUCCE=\r\nSS"));
         assertThat(body, containsString("<strong>Env :</strong> dev"));
         assertThat(body, containsString("myCustomMessage"));
-        assertThat(body, containsString("Content-Type: image/png; filename=kestra.png; name=kestra.png"));
+        assertThat(body, containsString("Content-Type: image/png; name=kestra.png"));
+        assertThat(body, containsString("Content-Disposition: inline; filename=kestra.png"));
 
         MimeBodyPart filePart = ((MimeBodyPart) content.getBodyPart(1));
         String file = IOUtils.toString(filePart.getInputStream(), StandardCharsets.UTF_8);
 
-        assertThat(filePart.getContentType(), is("text/yaml; filename=" + attachmentFilename + "; name=" + attachmentFilename));
+        assertThat(filePart.getContentType(), is("text/yaml; name=" + attachmentFilename));
+        assertThat(filePart.getDisposition(), is("attachment"));
         assertThat(filePart.getFileName(), is(attachmentFilename));
-        assertThat(file.replace("\r", ""), is(IOUtils.toString(storageInterface.get(MAIN_TENANT, null, putAttachment), StandardCharsets.UTF_8)));
+        assertThat(
+            file.replace("\r", ""),
+            is(IOUtils.toString(storageInterface.get(MAIN_TENANT, null, putAttachment), StandardCharsets.UTF_8))
+        );
     }
 
     @Test


### PR DESCRIPTION
Companion fix for #60.

Simple Java Mail 9 removed the `to`, `cc`, and `bcc` builder methods used by `MailSend`. This migrates all three recipient types to `withRecipients` while preserving address parsing and recipient semantics.

The MIME assertions are updated for the new library's equivalent header serialization: content type `name` and content disposition `filename` are now emitted separately.

Verification:
- focused `MailSendTest`: 4/4 passed;
- `./gradlew check`: 9/9 tests passed, documentation lint passed;
- no unrelated production behavior was changed.