### PR TITLE
docs: state connection properties per task instead of plugin defaults

### DIFF
--- a/src/main/resources/doc/io.kestra.plugin.email.md
+++ b/src/main/resources/doc/io.kestra.plugin.email.md
@@ -4,7 +4,7 @@ Send email from flows and trigger flows from incoming email using standard SMTP 
 
 ## Authentication
 
-Set `host`, `port`, `username`, and `password` on each task, or apply them globally with [plugin defaults](https://kestra.io/docs/workflow-components/plugin-defaults) to avoid repetition. Store credentials in [secrets](https://kestra.io/docs/concepts/secret). Control encryption via `transportStrategy`: the default `SMTPS` uses implicit TLS on port 465; set it to `SMTP_TLS` for STARTTLS on port 587; or `SMTP` for unencrypted connections.
+Set `host`, `port`, `username`, and `password` on each task. Store credentials in [secrets](https://kestra.io/docs/concepts/secret). Control encryption via `transportStrategy`: the default `SMTPS` uses implicit TLS on port 465; set it to `SMTP_TLS` for STARTTLS on port 587; or `SMTP` for unencrypted connections.
 
 ## Tasks
 


### PR DESCRIPTION
Removes references to `pluginDefaults`, which was removed in the latest Kestra
release, from this plugin's documentation. Connection properties are now stated
on each task.

Part of a sweep across the plugin repositories: the docs link to
`kestra.io/docs/workflow-components/plugin-defaults` and the surrounding prose
would otherwise point users at a removed feature and a dead docs page.